### PR TITLE
Android : fix map zoom & shadows

### DIFF
--- a/src/components/DropyMap.js
+++ b/src/components/DropyMap.js
@@ -133,7 +133,6 @@ const DropyMap = ({ dropiesAround, retrieveDropy, museumVisible, selectedDropyIn
         }}
         onMapLoaded={() => setMapIsReady(true)}
         showsPointsOfInterest={false}
-        cacheEnabled
         onRegionChange={onRegionChange}
       >
         {retrievedDropies != null ? (

--- a/src/states/SocketContextProvider.js
+++ b/src/states/SocketContextProvider.js
@@ -1,5 +1,5 @@
 import React, { createContext, useEffect, useRef, useState } from 'react';
-import { AppState, View, StyleSheet, Platform } from 'react-native';
+import { AppState, View, StyleSheet } from 'react-native';
 
 import { Manager } from 'socket.io-client';
 

--- a/src/styles/Styles.js
+++ b/src/styles/Styles.js
@@ -2,6 +2,8 @@ import { Platform } from 'react-native';
 import { responsiveFontSize } from 'react-native-responsive-dimensions';
 
 const FONT_SIZE_SCALE_FACTOR = 7;
+const IS_IOS = Platform.OS === 'ios';
+
 const scaleFromFigma = size => responsiveFontSize(size / FONT_SIZE_SCALE_FACTOR);
 
 export const Colors = {
@@ -21,37 +23,40 @@ export const Colors = {
 
   red: '#f28888',
   green: '#8FDCB7',
+
+  androidShadows: '#1d1d57',
+  androidSoftShadows: '#697180',
 };
 
 const Styles = {
   hardShadows: {
-    shadowColor: Colors.mainBlue,
+    shadowColor: IS_IOS ? Colors.mainBlue : Colors.androidShadows,
 
-    shadowOpacity: 0.5,
+    shadowOpacity: 10,
     shadowRadius: 12,
 
-    elevation: 7,
+    elevation: 15,
     shadowOffset: {
       width: 0,
-      height: Platform.OS !== 'ios' ? 0 : 5,
+      height: IS_IOS ? 0 : 5,
     },
   },
   softShadows: {
-    shadowColor: Colors.mainBlue,
+    shadowColor: IS_IOS ? Colors.mainBlue : Colors.androidSoftShadows,
     shadowOpacity: 0.25,
     shadowRadius: 15,
-    elevation: 5,
+    elevation: 10,
 
     shadowOffset: {
       width: 0,
-      height: Platform.OS !== 'ios' ? 0 : 5,
+      height: 0,
     },
   },
   blueShadow: {
-    shadowColor: Colors.mainBlue,
+    shadowColor: IS_IOS ? Colors.mainBlue : Colors.androidShadows,
     shadowOpacity: 0.3,
     shadowRadius: 5,
-    elevation: 5,
+    elevation: 10,
 
     shadowOffset: {
       width: 0,
@@ -63,7 +68,7 @@ const Styles = {
     justifyContent: 'center',
   },
   safeAreaView: {
-    paddingTop: Platform.OS === 'ios' ? 0 : 20,
+    paddingTop: IS_IOS ? 0 : 20,
   },
 };
 


### PR DESCRIPTION
C'était le props cacheEnabled qui niquait le zoom de la map.
Le zoom reste néanmoins très degueu, je ne sais pas pourquoi ce n'est pas centré quand tu zoom, j'ai l'impression qu'il y a juste de gros problèmes de précision (Déplacé dans une autre issue).

Donc bon je sens qua ça va finir avec la map dezoomé h24 et on zoom nous même avec un transform scale x)

J'en ai profité pour ajuster un peu les ombres sur android